### PR TITLE
add support for /comments/:id endpoint (and derivatives) (spikecodes#568)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,11 @@ async fn main() {
 	app.at("/r/:sub/comments/:id").get(|r| post::item(r).boxed());
 	app.at("/r/:sub/comments/:id/:title").get(|r| post::item(r).boxed());
 	app.at("/r/:sub/comments/:id/:title/:comment_id").get(|r| post::item(r).boxed());
+	app.at("/comments/:id").get(|r| post::item(r).boxed());
+	app.at("/comments/:id/comments").get(|r| post::item(r).boxed());
+	app.at("/comments/:id/comments/:comment_id").get(|r| post::item(r).boxed());
+	app.at("/comments/:id/:title").get(|r| post::item(r).boxed());
+	app.at("/comments/:id/:title/:comment_id").get(|r| post::item(r).boxed());
 
 	app.at("/r/:sub/search").get(|r| search::find(r).boxed());
 


### PR DESCRIPTION
(comment taken from original PR to libreddit -- spikecodes/libreddit#578)

Implements support for GET to the following endpoints:

* `/comments/:id`
* `/comments/:id/comment/:comment_id`
* `/comments/:id/:title`
* `/comments/:id/:title/:comment_id`

Resolves spikecodes/libreddit#568. Confirmed working. See screenshots below.
![Screenshot from 2022-08-22 17-56-57](https://user-images.githubusercontent.com/13266270/186040183-8cfa5b54-4e4c-450c-9289-8bb819a7f632.png)
![Screenshot from 2022-08-22 17-57-35](https://user-images.githubusercontent.com/13266270/186040186-2f927913-083d-4e50-81eb-543c34d84b5e.png)
![Screenshot from 2022-08-22 17-58-51](https://user-images.githubusercontent.com/13266270/186040187-bd041b13-116f-4ac9-85eb-cc02705a9b40.png)
![Screenshot from 2022-08-22 17-59-20](https://user-images.githubusercontent.com/13266270/186040189-ae146acb-dcff-47d4-aeed-a138a43138ac.png)

