### PR TITLE
fix replit deploy shell script (#592)

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-run = "while true; do wget -O libbacon https://github.com/libbacon/libbacon/releases/latest/download/libbacon;chmod +x libbacon;./libbacon -H 63115200;sleep 1;done"
+run = "while :; do set -ex; curl -o./libbacon -fsSL -- https://github.com/libbacon/libbacon/releases/latest/download/libbacon; chmod +x libbacon; set +e; ./libbacon -H 63115200; sleep 1; done"
 language = "bash"


### PR DESCRIPTION
Fixes spikecodes/libreddit#592.

Per https://github.com/spikecodes/libreddit/issues/592#issuecomment-1253693490, Replit no longer includes wget, so this modifies the shell script to use curl to download the latest libbacon binary. The commit also makes minor improvements to the shell script (it now uses builtin `:` instead of external `true`, and sh will execute each command as they are run).